### PR TITLE
base64エンコードされたbatch_tokenをCGI::parseすることでリクエストパラメータに==が入る問題を修正

### DIFF
--- a/lib/square/utils/api.rb
+++ b/lib/square/utils/api.rb
@@ -64,9 +64,7 @@ module Square
       # @see https://connect.squareup.com/docs/connect#pagination
       def parse_batch_token(response_header_link)
         return if response_header_link.nil?
-        link = response_header_link.scan(/\<https:\/\/[^\?]+\?([^\>]*)\>;rel='next'/)[0][0]
-        options = CGI::parse(link)
-        options['batch_token'].first
+        response_header_link.match(/batch_token=(?<batch_token>.+)\>.+\Z/)[:batch_token]
       end
 
     end

--- a/lib/square/utils/api.rb
+++ b/lib/square/utils/api.rb
@@ -64,7 +64,7 @@ module Square
       # @see https://connect.squareup.com/docs/connect#pagination
       def parse_batch_token(response_header_link)
         return if response_header_link.nil?
-        response_header_link.match(/batch_token=(?<batch_token>.+)\>.+\Z/)[:batch_token]
+        response_header_link.match(/batch_token=(?<batch_token>.+)\>.+\z/)[:batch_token]
       end
 
     end

--- a/square.gemspec
+++ b/square.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 1.3.5'
 
   spec.add_dependency 'faraday'
-  spec.add_dependency 'faraday_middleware'
+  spec.add_dependency 'faraday_middleware', '<= 0.9.0'
   spec.add_dependency 'simple_oauth'
 
   spec.add_development_dependency 'bundler'

--- a/test/square/utils/api_test.rb
+++ b/test/square/utils/api_test.rb
@@ -67,7 +67,18 @@ describe Square::Utils::API do
         -> { @clean_room.send(:parse_date, 1) }.must_raise ArgumentError
       end
     end
-
   end
 
+  describe '#parse_batch_token' do
+    let(:response_header_link){
+      "Link: <https://connect.squareup.com/v1/me/payments?begin_time=2014-01-01T14%3A59%3A59%2B00%3A00&end_time=2014-12-30T20%3A59%3A59Z&batch_token=#{batch_token_str}>;rel='next'"
+    }
+    let(:batch_token_str){
+      'LoremipsumdolorsitametconsecteturadipisicingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexeitationullamcolabo%3D%3D'
+    }
+
+    it 'returns the correct batch token string' do
+      @clean_room.send(:parse_batch_token, response_header_link).must_equal batch_token_str
+    end
+  end
 end


### PR DESCRIPTION
base64では変換時に文字列が足りない場合==で埋めるためレスポンスヘッダのlinkではエスケープされているが、CGI::parseを行うとアンエスケープされるので`parse_batch_token `メソッドをそのまま使うと以下の形式でリクエストを行うことになり、500 エラーが返ってくる。
`https://connect.squareup.com/v1/me/payments?batch_token=文字列==`

CGI::parseをする必要はないので、matchでbatch_tokenの値のみを抜き出すようにした。
