### PR TITLE
Make tender.id readable

### DIFF
--- a/lib/square/connect/model/tender.rb
+++ b/lib/square/connect/model/tender.rb
@@ -36,7 +36,7 @@ module Square
         'UNKNOWN'
       ]
 
-      attr_reader :type, :name, :card_brand, :pan_suffix, :entry_method, :payment_note
+      attr_reader :type, :name, :card_brand, :pan_suffix, :entry_method, :payment_note, :id
 
       def total_money
         return unless @attrs[:total_money]

--- a/test/square/connect/model/tender_test.rb
+++ b/test/square/connect/model/tender_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 describe Square::Connect::Tender do
   let(:tender) do
     Square::Connect::Tender.new(
+      id: "7OlOmDbt3PMV4CT1q0NnKQB",
       type: "CREDIT_CARD",
       card_brand: "VISA",
       name: "VISA-1234",
@@ -61,6 +62,12 @@ describe Square::Connect::Tender do
   describe '#entry_method' do
     it 'returns string value' do
       tender.entry_method.must_equal "SWIPED"
+    end
+  end
+
+  describe "#id" do
+    it 'returns string value' do
+      tender.id.must_equal "7OlOmDbt3PMV4CT1q0NnKQB"
     end
   end
 


### PR DESCRIPTION
Tenderの `id` を readable にする