### PR TITLE
locationsのurlはv1/meの様

### DIFF
--- a/lib/square/connect/api/locations.rb
+++ b/lib/square/connect/api/locations.rb
@@ -14,7 +14,7 @@ module Square
         # @raise [Square::Error::Unauthorized] Error raised when supplied user credentials are invalid.
         # @return [Square::Connect::Locations]
         def locations
-          response = objects_from_response(Square::Connect::Location, :get, "/me/locations")
+          response = objects_from_response(Square::Connect::Location, :get, "/me")
           response[:objects]          
         end
 

--- a/lib/square/version.rb
+++ b/lib/square/version.rb
@@ -2,7 +2,7 @@ module Square
   class Version
     MAJOR = 0 unless defined? Square::Version::MAJOR
     MINOR = 3 unless defined? Square::Version::MINOR
-    PATCH = 0 unless defined? Square::Version::PATCH
+    PATCH = 1 unless defined? Square::Version::PATCH
     PRE = nil unless defined? Square::Version::PRE
 
     class << self

--- a/lib/square/version.rb
+++ b/lib/square/version.rb
@@ -2,7 +2,7 @@ module Square
   class Version
     MAJOR = 0 unless defined? Square::Version::MAJOR
     MINOR = 3 unless defined? Square::Version::MINOR
-    PATCH = 1 unless defined? Square::Version::PATCH
+    PATCH = 0 unless defined? Square::Version::PATCH
     PRE = nil unless defined? Square::Version::PRE
 
     class << self


### PR DESCRIPTION
url:"v1/me/locations"は404:NotFoundのエラーとなる。
その反面、url:"v1/me"をとると、locationsの様なjsonが得られる。

そこで、"v1/me/locations"を"v1/me"に変更した。
```
[119] pry(#<Importer::ApiClient::SquareApiClient>)> url = URI.parse('https://connect.broadway.squareup.com/v1/me')
[120] pry(#<Importer::ApiClient::SquareApiClient>)> https = Net::HTTP.new(url.host,url.port)
[121] pry(#<Importer::ApiClient::SquareApiClient>)> https.use_ssl = true
[122] pry(#<Importer::ApiClient::SquareApiClient>)> req = Net::HTTP::Get.new(url.request_uri)
[123] pry(#<Importer::ApiClient::SquareApiClient>)> req['Authorization'] = 'Bearer sq0ats-L309xldBeYxZvBRZo2iCKg'
[124] pry(#<Importer::ApiClient::SquareApiClient>)> req['Accept'] = 'application/json'
[125] pry(#<Importer::ApiClient::SquareApiClient>)> req.body = ''
[126] pry(#<Importer::ApiClient::SquareApiClient>)> res = https.request(req)
=> #<Net::HTTPOK 200 OK readbody=true>
[127] pry(#<Importer::ApiClient::SquareApiClient>)>
[128] pry(#<Importer::ApiClient::SquareApiClient>)> res.body
=> "{\"account_capabilities\":[\"CREDIT_CARD_PROCESSING\"],\"id\":\"EQXJ2ZSMPHE02\",\"name\":\"\xE6\xA8\xAA\xE8\xB7\xAF \xE9\x9A\x86\",\"email\":\"yokoji@freee.co.jp\",\"country_code\":\"JP\",\"language_code\":\"ja-JP\",\"business_name\":\"\xE6\xA8\xAA\xE8\xB7\xAF \xE9\x9A\x86\",\"business_address\":{\"address_line_1\":\"\xE4\xB8\x89\xE7\x94\xB0\xE3\x80\x80\xEF\xBC\x95\xE4\xB8\x81\xE7\x9B\xAE\",\"locality\":\"\xE6\xB8\xAF\xE5\x8C\xBA\",\"administrative_district_level_1\":\"13\",\"postal_code\":\"108\",\"country_code\":\"JP\"},\"business_phone\":{\"calling_code\":\"+81\",\"number\":\"9045784723\"},\"business_type\":\"ACCOUNTING\",\"account_type\":\"LOCATION\",\"location_details\":{\"nickname\":\"\xE6\xA8\xAA\xE8\xB7\xAF \xE9\x9A\x86\"},\"currency_code\":\"JPY\"}"
[129] pry(#<Importer::ApiClient::SquareApiClient>)>
```