### PR TITLE
Update pry-byebug and faraday

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: circleci/ruby:2.3.4-node-browsers
+    - image: circleci/ruby:2.5.8-node-browsers
     environment:
     - CIRCLE_ARTIFACTS: "/tmp/test-results"
     working_directory: ~/repo

--- a/square.gemspec
+++ b/square.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.4'
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday', '~> 0.17'
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'simple_oauth'
 
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'redcarpet'
   spec.add_development_dependency 'yard'
-  spec.add_development_dependency 'pry-byebug', '~> 3.4'
+  spec.add_development_dependency 'pry-byebug', '~> 3.9'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'rspec', '~> 3.5'

--- a/square.gemspec
+++ b/square.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.4'
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday', '~> 0.17'
+  spec.add_dependency 'faraday', '~> 0.12.2'
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'simple_oauth'
 


### PR DESCRIPTION
## :memo: 概要
masterのままだとrspecが失敗したので、パスするようにした。

### 1. pry-byebugのバージョン
```
NameError:
  uninitialized constant Pry::Command::ExitAll
```
[circle ciエラー箇所](https://app.circleci.com/pipelines/github/C-FO/square/3/workflows/2b7cead1-6aa2-4f6d-acef-79b6abcdaf7b/jobs/69)

https://github.com/pry/pry/issues/2121#issuecomment-602975164 をみると、pryが0.13の場合はpry-byebugを3.9にしないといけないよう


### 2. faradayのバージョン

```
NameError:
       uninitialized constant Faraday::Error::ClientError
       Did you mean?  Faraday::ClientError
```
[circle ciエラー箇所](https://app.circleci.com/pipelines/github/C-FO/square/4/workflows/3f09678d-35b7-4531-a71e-7c9600133ae6/jobs/70)

https://www.gitmemory.com/issue/github-changelog-generator/github-changelog-generator/741/541461443 を参考に0.17に


### 3.  circleciのrubyバージョン

1, 2を修正すると、circle ciで下記エラー
```
Bundler could not find compatible versions for gem "ruby":
```
https://app.circleci.com/pipelines/github/C-FO/square/5/workflows/97bd9836-8f34-4141-be9a-388c3f86829c/jobs/71

=> circleciのrubyのバージョンを2.5.8に

## :heavy_check_mark: 動作確認
### 動作確認内容
- [x] CIが通ること